### PR TITLE
Multiple proxies added

### DIFF
--- a/pallets/collective-proxy/src/lib.rs
+++ b/pallets/collective-proxy/src/lib.rs
@@ -193,11 +193,13 @@ pub mod pallet {
         ) -> DispatchResult {
             T::CollectiveProxy::ensure_origin(origin)?;
             Proxies::<T>::try_mutate(|proxies| -> Result<(), DispatchError> {
-                let proxy_def = ProxyDefinition {
-                    proxy: proxy.clone(),
-                    filter: filter.clone(),
-                };
-                proxies.try_push(proxy_def).map_err(|_| Error::<T>::TooManyProxies)?;
+                if !proxies.iter().any(|p| p.proxy == proxy && p.filter.is_superset(&filter)) {
+                    let proxy_def = ProxyDefinition {
+                        proxy: proxy.clone(),
+                        filter: filter.clone(),
+                    };
+                    proxies.try_push(proxy_def).map_err(|_| Error::<T>::TooManyProxies)?;
+                }
                 Ok(())
             })
         }

--- a/pallets/collective-proxy/src/lib.rs
+++ b/pallets/collective-proxy/src/lib.rs
@@ -40,11 +40,36 @@ mod benchmarking;
 pub mod weights;
 pub use weights::WeightInfo;
 
+/// The parameters under which a particular account has a proxy relationship with some other
+/// account.
+#[derive(
+    Encode,
+    Decode,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    MaxEncodedLen,
+    TypeInfo,
+)]
+pub struct ProxyDefinition<AccountId, CallFilter> {
+    /// The account which may act on behalf of another.
+    pub proxy: AccountId,
+    /// A value defining the subset of calls that it is allowed to make.
+    pub filter: CallFilter,
+}
+
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
 
+    /// The current storage version.
+    pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
     #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
     pub struct Pallet<T>(_);
 
     // TODO: The pallet is intentionally very basic. It could be improved to handle more origins, more aliases, etc.
@@ -68,11 +93,21 @@ pub mod pallet {
         /// Origin that can act on behalf of the collective.
         type CollectiveProxy: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 
-        /// Account representing the collective treasury.
-        type ProxyAccountId: Get<Self::AccountId>;
-
         /// Filter to determine whether a call can be executed or not.
-        type CallFilter: InstanceFilter<<Self as Config>::RuntimeCall> + Default;
+        type CallFilter: InstanceFilter<<Self as Config>::RuntimeCall>
+            + Member
+            + Clone
+            + Ord
+            + PartialOrd
+            + Encode
+            + Decode
+            + MaxEncodedLen
+            + TypeInfo
+            + Default;
+
+        /// The maximum amount of proxies allowed for a single account.
+        #[pallet::constant]
+        type MaxProxies: Get<u32>;
 
         /// Weight info
         type WeightInfo: WeightInfo;
@@ -84,6 +119,25 @@ pub mod pallet {
         /// Community proxy call executed successfully.
         CollectiveProxyExecuted { result: DispatchResult },
     }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// There are too many proxies registered
+        TooManyProxies,
+        /// Proxy registration not found.
+        NotFound,
+    }
+
+    /// The set of account proxies
+    #[pallet::storage]
+    pub type Proxies<T: Config> = StorageValue<
+        _,
+        BoundedVec<
+            ProxyDefinition<T::AccountId, T::CallFilter>,
+            T::MaxProxies,
+        >,
+        ValueQuery,
+    >;
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
@@ -98,19 +152,22 @@ pub mod pallet {
 		})]
         pub fn execute_call(
             origin: OriginFor<T>,
+            filter: Option<T::CallFilter>,
             call: Box<<T as Config>::RuntimeCall>,
         ) -> DispatchResult {
             // Ensure origin is valid.
             T::CollectiveProxy::ensure_origin(origin)?;
 
+            let def = Self::find_proxy(filter)?;
+
             // Account authentication is ensured by the `CollectiveProxy` origin check.
             let mut origin: T::RuntimeOrigin =
-                frame_system::RawOrigin::Signed(T::ProxyAccountId::get()).into();
+                frame_system::RawOrigin::Signed(def.proxy).into();
 
             // Ensure custom filter is applied.
             origin.add_filter(move |c: &<T as frame_system::Config>::RuntimeCall| {
                 let c = <T as Config>::RuntimeCall::from_ref(c);
-                T::CallFilter::default().filter(c)
+                def.filter.filter(c)
             });
 
             // Dispatch the call.
@@ -120,6 +177,67 @@ pub mod pallet {
             });
 
             Ok(())
+        }
+
+        /// Register a proxy account for the sender that is able to make calls on its behalf.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// Parameters:
+        /// - `proxy`: The account that the `caller` would like to make a proxy.
+        /// - `filter`: Call filter used for the proxy
+        #[pallet::call_index(1)]
+        #[pallet::weight(T::WeightInfo::add_proxy(T::MaxProxies::get()))]
+        pub fn add_proxy(
+            origin: OriginFor<T>,
+            proxy: T::AccountId,
+            filter: T::CallFilter,
+        ) -> DispatchResult {
+            T::CollectiveProxy::ensure_origin(origin)?;
+            Proxies::<T>::try_mutate(|proxies| -> Result<(), DispatchError> {
+                let proxy_def = ProxyDefinition {
+                    proxy: proxy.clone(),
+                    filter: filter.clone(),
+                };
+                proxies.try_push(proxy_def).map_err(|_| Error::<T>::TooManyProxies)?;
+                Ok(())
+            })
+        }
+
+        /// Unregister a proxy account for the sender.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// Parameters:
+        /// - `proxy`: The account that the `caller` would like to remove as a proxy.
+        /// - `filter`: Call filter used for the proxy
+        #[pallet::call_index(2)]
+        #[pallet::weight(T::WeightInfo::remove_proxy(T::MaxProxies::get()))]
+        pub fn remove_proxy(
+            origin: OriginFor<T>,
+            proxy: T::AccountId,
+            filter: T::CallFilter,
+        ) -> DispatchResult {
+            T::CollectiveProxy::ensure_origin(origin)?;
+            Proxies::<T>::try_mutate(|proxies| -> Result<(), DispatchError> {
+                let proxy_def = ProxyDefinition {
+                    proxy: proxy.clone(),
+                    filter: filter.clone(),
+                };
+                proxies.retain(|def| def != &proxy_def);
+                Ok(())
+            })
+        }
+    }
+
+    impl<T: Config> Pallet<T> {
+        pub fn find_proxy(
+            filter: Option<T::CallFilter>,
+        ) -> Result<ProxyDefinition<T::AccountId, T::CallFilter>, DispatchError> {
+            let f = |x: &ProxyDefinition<T::AccountId, T::CallFilter>| -> bool {
+                filter.as_ref().map_or(true, |y| &x.filter == y)
+            };
+            Ok(Proxies::<T>::get().into_iter().find(f).ok_or(Error::<T>::NotFound)?)
         }
     }
 }

--- a/pallets/collective-proxy/src/lib.rs
+++ b/pallets/collective-proxy/src/lib.rs
@@ -150,13 +150,13 @@ pub mod pallet {
 		})]
         pub fn execute_call(
             origin: OriginFor<T>,
-            filter: Option<T::CallFilter>,
+            proxy: T::AccountId,
             call: Box<<T as Config>::RuntimeCall>,
         ) -> DispatchResult {
             // Ensure origin is valid.
             T::CollectiveProxy::ensure_origin(origin)?;
 
-            let def = Self::find_proxy(filter)?;
+            let def = Self::find_proxy(proxy)?;
 
             // Account authentication is ensured by the `CollectiveProxy` origin check.
             let mut origin: T::RuntimeOrigin =
@@ -230,10 +230,10 @@ pub mod pallet {
 
     impl<T: Config> Pallet<T> {
         pub fn find_proxy(
-            filter: Option<T::CallFilter>,
+            proxy: T::AccountId,
         ) -> Result<ProxyDefinition<T::AccountId, T::CallFilter>, DispatchError> {
             let f = |x: &ProxyDefinition<T::AccountId, T::CallFilter>| -> bool {
-                filter.as_ref().map_or(true, |y| &x.filter == y)
+                x.proxy == proxy
             };
             Ok(Proxies::<T>::get().into_iter().find(f).ok_or(Error::<T>::NotFound)?)
         }

--- a/pallets/collective-proxy/src/lib.rs
+++ b/pallets/collective-proxy/src/lib.rs
@@ -97,8 +97,6 @@ pub mod pallet {
         type CallFilter: InstanceFilter<<Self as Config>::RuntimeCall>
             + Member
             + Clone
-            + Ord
-            + PartialOrd
             + Encode
             + Decode
             + MaxEncodedLen

--- a/pallets/collective-proxy/src/lib.rs
+++ b/pallets/collective-proxy/src/lib.rs
@@ -93,6 +93,9 @@ pub mod pallet {
         /// Origin that can act on behalf of the collective.
         type CollectiveProxy: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 
+        /// Origin with permissions to add and remove proxies for the collective.
+        type ProxyAdmin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
+
         /// Filter to determine whether a call can be executed or not.
         type CallFilter: InstanceFilter<<Self as Config>::RuntimeCall>
             + Member
@@ -191,7 +194,7 @@ pub mod pallet {
             proxy: T::AccountId,
             filter: T::CallFilter,
         ) -> DispatchResult {
-            T::CollectiveProxy::ensure_origin(origin)?;
+            T::ProxyAdmin::ensure_origin(origin)?;
             Proxies::<T>::try_mutate(|proxies| -> Result<(), DispatchError> {
                 if !proxies.iter().any(|p| p.proxy == proxy && p.filter.is_superset(&filter)) {
                     let proxy_def = ProxyDefinition {
@@ -218,7 +221,7 @@ pub mod pallet {
             proxy: T::AccountId,
             filter: T::CallFilter,
         ) -> DispatchResult {
-            T::CollectiveProxy::ensure_origin(origin)?;
+            T::ProxyAdmin::ensure_origin(origin)?;
             Proxies::<T>::try_mutate(|proxies| -> Result<(), DispatchError> {
                 let proxy_def = ProxyDefinition {
                     proxy: proxy.clone(),

--- a/pallets/collective-proxy/src/mock.rs
+++ b/pallets/collective-proxy/src/mock.rs
@@ -113,8 +113,6 @@ ord_parameter_types! {
     Clone,
     Eq,
     PartialEq,
-    Ord,
-    PartialOrd,
     std::fmt::Debug,
     parity_scale_codec::Encode,
     parity_scale_codec::Decode,

--- a/pallets/collective-proxy/src/mock.rs
+++ b/pallets/collective-proxy/src/mock.rs
@@ -108,15 +108,39 @@ ord_parameter_types! {
     pub const CollectiveProxyManager: AccountId = PRIVILEGED_ACCOUNT;
 }
 
-#[derive(Default)]
-pub struct MockCallFilter;
+#[derive(
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    std::fmt::Debug,
+    parity_scale_codec::Encode,
+    parity_scale_codec::Decode,
+    parity_scale_codec::MaxEncodedLen,
+    scale_info::TypeInfo,
+)]
+pub enum MockCallFilter {
+    Any,
+    JustTransfer
+}
+impl Default for MockCallFilter {
+    fn default() -> Self {
+        Self::Any
+    }
+}
 impl InstanceFilter<RuntimeCall> for MockCallFilter {
     fn filter(&self, c: &RuntimeCall) -> bool {
-        matches!(
-            c,
-            RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death { .. })
-                | RuntimeCall::System(frame_system::Call::remark { .. })
-        )
+        match self {
+            MockCallFilter::Any => true,
+            MockCallFilter::JustTransfer => {
+                matches!(
+					c,
+					RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death { .. })
+				)
+            },
+        }
     }
 }
 
@@ -124,8 +148,8 @@ impl pallet_collective_proxy::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type CollectiveProxy = EnsureSignedBy<CollectiveProxyManager, AccountId>;
-    type ProxyAccountId = ProxyAccountId;
     type CallFilter = MockCallFilter;
+    type MaxProxies = ConstU32<2>;
     type WeightInfo = ();
 }
 

--- a/pallets/collective-proxy/src/mock.rs
+++ b/pallets/collective-proxy/src/mock.rs
@@ -146,6 +146,7 @@ impl pallet_collective_proxy::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type CollectiveProxy = EnsureSignedBy<CollectiveProxyManager, AccountId>;
+    type ProxyAdmin = EnsureSignedBy<CollectiveProxyManager, AccountId>;
     type CallFilter = MockCallFilter;
     type MaxProxies = ConstU32<2>;
     type WeightInfo = ();

--- a/pallets/collective-proxy/src/mock.rs
+++ b/pallets/collective-proxy/src/mock.rs
@@ -148,7 +148,6 @@ impl pallet_collective_proxy::Config for Test {
     type CollectiveProxy = EnsureSignedBy<CollectiveProxyManager, AccountId>;
     type ProxyAdmin = EnsureSignedBy<CollectiveProxyManager, AccountId>;
     type CallFilter = MockCallFilter;
-    type MaxProxies = ConstU32<2>;
     type WeightInfo = ();
 }
 

--- a/pallets/collective-proxy/src/tests.rs
+++ b/pallets/collective-proxy/src/tests.rs
@@ -27,7 +27,7 @@ fn execute_call_fails_for_invalid_origin() {
         assert_noop!(
             CollectiveProxy::execute_call(
                 RuntimeOrigin::signed(1),
-                None,
+                1,
                 Box::new(RuntimeCall::Balances(BalancesCall::transfer_allow_death {
                     dest: 2,
                     value: 10
@@ -52,7 +52,7 @@ fn execute_call_filters_not_allowed_call() {
         // Call is filtered, but `execute_call` succeeds.
         assert_ok!(CollectiveProxy::execute_call(
             RuntimeOrigin::signed(PRIVILEGED_ACCOUNT),
-            Some(MockCallFilter::JustTransfer),
+            COMMUNITY_ACCOUNT,
             Box::new(RuntimeCall::Balances(BalancesCall::transfer_keep_alive {
                 dest: 2,
                 value: 10
@@ -90,7 +90,7 @@ fn execute_call_succeeds() {
 
         assert_ok!(CollectiveProxy::execute_call(
             RuntimeOrigin::signed(PRIVILEGED_ACCOUNT),
-            Some(MockCallFilter::JustTransfer),
+            COMMUNITY_ACCOUNT,
             Box::new(RuntimeCall::Balances(BalancesCall::transfer_allow_death {
                 dest: 2,
                 value: transfer_value

--- a/pallets/collective-proxy/src/tests.rs
+++ b/pallets/collective-proxy/src/tests.rs
@@ -39,6 +39,20 @@ fn execute_call_fails_for_invalid_origin() {
 }
 
 #[test]
+fn add_proxy_fails_for_invalid_origin() {
+    ExtBuilder::build().execute_with(|| {
+        assert_noop!(
+            CollectiveProxy::add_proxy(
+                RuntimeOrigin::signed(1),
+                1,
+                MockCallFilter::JustTransfer
+            ),
+            BadOrigin
+        );
+    });
+}
+
+#[test]
 fn execute_call_filters_not_allowed_call() {
     ExtBuilder::build().execute_with(|| {
         let init_balance = Balances::free_balance(COMMUNITY_ACCOUNT);

--- a/pallets/collective-proxy/src/tests.rs
+++ b/pallets/collective-proxy/src/tests.rs
@@ -27,6 +27,7 @@ fn execute_call_fails_for_invalid_origin() {
         assert_noop!(
             CollectiveProxy::execute_call(
                 RuntimeOrigin::signed(1),
+                None,
                 Box::new(RuntimeCall::Balances(BalancesCall::transfer_allow_death {
                     dest: 2,
                     value: 10
@@ -42,9 +43,16 @@ fn execute_call_filters_not_allowed_call() {
     ExtBuilder::build().execute_with(|| {
         let init_balance = Balances::free_balance(COMMUNITY_ACCOUNT);
 
+        assert_ok!(CollectiveProxy::add_proxy(
+            RuntimeOrigin::signed(PRIVILEGED_ACCOUNT),
+            COMMUNITY_ACCOUNT,
+            MockCallFilter::JustTransfer
+        ));
+
         // Call is filtered, but `execute_call` succeeds.
         assert_ok!(CollectiveProxy::execute_call(
             RuntimeOrigin::signed(PRIVILEGED_ACCOUNT),
+            Some(MockCallFilter::JustTransfer),
             Box::new(RuntimeCall::Balances(BalancesCall::transfer_keep_alive {
                 dest: 2,
                 value: 10
@@ -74,8 +82,15 @@ fn execute_call_succeeds() {
         let init_balance = Balances::free_balance(COMMUNITY_ACCOUNT);
         let transfer_value = init_balance / 3;
 
+        assert_ok!(CollectiveProxy::add_proxy(
+            RuntimeOrigin::signed(PRIVILEGED_ACCOUNT),
+            COMMUNITY_ACCOUNT,
+            MockCallFilter::JustTransfer
+        ));
+
         assert_ok!(CollectiveProxy::execute_call(
             RuntimeOrigin::signed(PRIVILEGED_ACCOUNT),
+            Some(MockCallFilter::JustTransfer),
             Box::new(RuntimeCall::Balances(BalancesCall::transfer_allow_death {
                 dest: 2,
                 value: transfer_value

--- a/pallets/collective-proxy/src/weights.rs
+++ b/pallets/collective-proxy/src/weights.rs
@@ -50,6 +50,8 @@ use core::marker::PhantomData;
 /// Weight functions needed for pallet_collective_proxy.
 pub trait WeightInfo {
 	fn execute_call() -> Weight;
+	fn add_proxy(p: u32, ) -> Weight;
+	fn remove_proxy(p: u32, ) -> Weight;
 }
 
 /// Weights for pallet_collective_proxy using the Substrate node and recommended hardware.
@@ -62,6 +64,28 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 7_732_000 picoseconds.
 		Weight::from_parts(7_950_000, 0)
 	}
+	fn add_proxy(p: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `161 + p * (37 ±0)`
+		//  Estimated: `4706`
+		// Minimum execution time: 21_495_000 picoseconds.
+		Weight::from_parts(22_358_457, 4706)
+			// Standard Error: 1_606
+			.saturating_add(Weight::from_parts(64_322, 0).saturating_mul(p.into()))
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	fn remove_proxy(p: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `161 + p * (37 ±0)`
+		//  Estimated: `4706`
+		// Minimum execution time: 21_495_000 picoseconds.
+		Weight::from_parts(22_579_308, 4706)
+			// Standard Error: 2_571
+			.saturating_add(Weight::from_parts(62_404, 0).saturating_mul(p.into()))
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -72,5 +96,27 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 7_732_000 picoseconds.
 		Weight::from_parts(7_950_000, 0)
+	}
+	fn add_proxy(p: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `161 + p * (37 ±0)`
+		//  Estimated: `4706`
+		// Minimum execution time: 21_495_000 picoseconds.
+		Weight::from_parts(22_358_457, 4706)
+			// Standard Error: 1_606
+			.saturating_add(Weight::from_parts(64_322, 0).saturating_mul(p.into()))
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	fn remove_proxy(p: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `161 + p * (37 ±0)`
+		//  Estimated: `4706`
+		// Minimum execution time: 21_495_000 picoseconds.
+		Weight::from_parts(22_579_308, 4706)
+			// Standard Error: 2_571
+			.saturating_add(Weight::from_parts(62_404, 0).saturating_mul(p.into()))
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/collective-proxy/src/weights.rs
+++ b/pallets/collective-proxy/src/weights.rs
@@ -50,8 +50,8 @@ use core::marker::PhantomData;
 /// Weight functions needed for pallet_collective_proxy.
 pub trait WeightInfo {
 	fn execute_call() -> Weight;
-	fn add_proxy(p: u32, ) -> Weight;
-	fn remove_proxy(p: u32, ) -> Weight;
+	fn add_proxy() -> Weight;
+	fn remove_proxy() -> Weight;
 }
 
 /// Weights for pallet_collective_proxy using the Substrate node and recommended hardware.
@@ -64,25 +64,23 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 7_732_000 picoseconds.
 		Weight::from_parts(7_950_000, 0)
 	}
-	fn add_proxy(p: u32, ) -> Weight {
+	fn add_proxy() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `161 + p * (37 ±0)`
 		//  Estimated: `4706`
 		// Minimum execution time: 21_495_000 picoseconds.
 		Weight::from_parts(22_358_457, 4706)
 			// Standard Error: 1_606
-			.saturating_add(Weight::from_parts(64_322, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	fn remove_proxy(p: u32, ) -> Weight {
+	fn remove_proxy() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `161 + p * (37 ±0)`
 		//  Estimated: `4706`
 		// Minimum execution time: 21_495_000 picoseconds.
 		Weight::from_parts(22_579_308, 4706)
 			// Standard Error: 2_571
-			.saturating_add(Weight::from_parts(62_404, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -97,25 +95,23 @@ impl WeightInfo for () {
 		// Minimum execution time: 7_732_000 picoseconds.
 		Weight::from_parts(7_950_000, 0)
 	}
-	fn add_proxy(p: u32, ) -> Weight {
+	fn add_proxy() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `161 + p * (37 ±0)`
 		//  Estimated: `4706`
 		// Minimum execution time: 21_495_000 picoseconds.
 		Weight::from_parts(22_358_457, 4706)
 			// Standard Error: 1_606
-			.saturating_add(Weight::from_parts(64_322, 0).saturating_mul(p.into()))
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	fn remove_proxy(p: u32, ) -> Weight {
+	fn remove_proxy() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `161 + p * (37 ±0)`
 		//  Estimated: `4706`
 		// Minimum execution time: 21_495_000 picoseconds.
 		Weight::from_parts(22_579_308, 4706)
 			// Standard Error: 2_571
-			.saturating_add(Weight::from_parts(62_404, 0).saturating_mul(p.into()))
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1465,7 +1465,18 @@ parameter_types! {
     pub CommunityTreasuryAccountId: AccountId = CommunityTreasuryPalletId::get().into_account_truncating();
 }
 
-#[derive(Default)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    parity_scale_codec::Encode,
+    parity_scale_codec::Decode,
+    parity_scale_codec::MaxEncodedLen,
+    scale_info::TypeInfo,
+)]
 pub struct CommunityCouncilCallFilter;
 impl InstanceFilter<RuntimeCall> for CommunityCouncilCallFilter {
     fn filter(&self, c: &RuntimeCall) -> bool {
@@ -1483,8 +1494,8 @@ impl pallet_collective_proxy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type CollectiveProxy = EnsureRootOrTwoThirdsCommunityCouncil;
-    type ProxyAccountId = CommunityTreasuryAccountId;
     type CallFilter = CommunityCouncilCallFilter;
+    type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1496,7 +1496,6 @@ impl pallet_collective_proxy::Config for Runtime {
     type CollectiveProxy = EnsureRootOrTwoThirdsCommunityCouncil;
     type ProxyAdmin = EnsureRootOrTwoThirdsCommunityCouncil;
     type CallFilter = CommunityCouncilCallFilter;
-    type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1494,6 +1494,7 @@ impl pallet_collective_proxy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type CollectiveProxy = EnsureRootOrTwoThirdsCommunityCouncil;
+    type ProxyAdmin = EnsureRootOrTwoThirdsCommunityCouncil;
     type CallFilter = CommunityCouncilCallFilter;
     type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -1140,7 +1140,6 @@ impl pallet_collective_proxy::Config for Runtime {
     type CollectiveProxy = EnsureRootOrTwoThirdsCommunityCouncil;
     type ProxyAdmin = EnsureRootOrTwoThirdsCommunityCouncil;
     type CallFilter = CommunityCouncilCallFilter;
-    type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -1138,6 +1138,7 @@ impl pallet_collective_proxy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type CollectiveProxy = EnsureRootOrTwoThirdsCommunityCouncil;
+    type ProxyAdmin = EnsureRootOrTwoThirdsCommunityCouncil;
     type CallFilter = CommunityCouncilCallFilter;
     type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -1109,7 +1109,18 @@ parameter_types! {
     pub CommunityTreasuryAccountId: AccountId = CommunityTreasuryPalletId::get().into_account_truncating();
 }
 
-#[derive(Default)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    parity_scale_codec::Encode,
+    parity_scale_codec::Decode,
+    parity_scale_codec::MaxEncodedLen,
+    scale_info::TypeInfo,
+)]
 pub struct CommunityCouncilCallFilter;
 impl InstanceFilter<RuntimeCall> for CommunityCouncilCallFilter {
     fn filter(&self, c: &RuntimeCall) -> bool {
@@ -1127,8 +1138,8 @@ impl pallet_collective_proxy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type CollectiveProxy = EnsureRootOrTwoThirdsCommunityCouncil;
-    type ProxyAccountId = CommunityTreasuryAccountId;
     type CallFilter = CommunityCouncilCallFilter;
+    type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1534,6 +1534,7 @@ impl pallet_collective_proxy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type CollectiveProxy = EnsureRootOrHalfCommunityCouncil;
+    type ProxyAdmin = EnsureRootOrHalfCommunityCouncil;
     type CallFilter = CommunityCouncilCallFilter;
     type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1536,7 +1536,6 @@ impl pallet_collective_proxy::Config for Runtime {
     type CollectiveProxy = EnsureRootOrHalfCommunityCouncil;
     type ProxyAdmin = EnsureRootOrHalfCommunityCouncil;
     type CallFilter = CommunityCouncilCallFilter;
-    type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1505,7 +1505,18 @@ parameter_types! {
     pub CommunityTreasuryAccountId: AccountId = CommunityTreasuryPalletId::get().into_account_truncating();
 }
 
-#[derive(Default)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    parity_scale_codec::Encode,
+    parity_scale_codec::Decode,
+    parity_scale_codec::MaxEncodedLen,
+    scale_info::TypeInfo,
+)]
 pub struct CommunityCouncilCallFilter;
 impl InstanceFilter<RuntimeCall> for CommunityCouncilCallFilter {
     fn filter(&self, c: &RuntimeCall) -> bool {
@@ -1523,8 +1534,8 @@ impl pallet_collective_proxy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type CollectiveProxy = EnsureRootOrHalfCommunityCouncil;
-    type ProxyAccountId = CommunityTreasuryAccountId;
     type CallFilter = CommunityCouncilCallFilter;
+    type MaxProxies = ConstU32<2>;
     type WeightInfo = pallet_collective_proxy::weights::SubstrateWeight<Runtime>;
 }
 


### PR DESCRIPTION
In my solution I tried to minimize the changes in the pallet's API and only add minimal support for several proxy accounts. I don't know the usecase that's why I decided to keep the current design with one origin (and just add multiple proxies for it). Of course it would be possible to extend the pallet even further and add map <Origin, Vec<ProxyAccount>> but it would change the pallet too dramatically and may be it would be better to create just a new one instead. 

TODO:
- Events of proxy registration\de-registration (do we need them?)
- More tests. I just modified the existing ones to reflect the new logic
